### PR TITLE
FIX: SGLN calc_check_digit() returns 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+### v1.1
+
+- Fixed incorrect SGLN check digit calculation if the sum of digits was a multiple of 10. Thanks @endreszabo!
+
+
 ### v1.0
 
 - Initial release.

--- a/epc/__init__.py
+++ b/epc/__init__.py
@@ -1,3 +1,3 @@
 "Utilities for generating and reading electronic product codes."
 
-__version__ = '1.0'
+__version__ = '1.1'

--- a/epc/schemes/GID.py
+++ b/epc/schemes/GID.py
@@ -190,7 +190,7 @@ class GID(EpcScheme):
         :type serial_number: str, int
 
         :raises ValueError: Unable to convert string to an integer.
-        :raises AttributeError: Input outside valid range (0 and 68719476735).
+        :raises AttributeError: Input outside valid range (0 to 68719476735).
 
         :return: The GID tag object.
         :rtype: :class:`epc.schemes.GID`

--- a/epc/schemes/SGLN.py
+++ b/epc/schemes/SGLN.py
@@ -483,8 +483,7 @@ class SGLN(EpcScheme):
             else:
                 odds.append(int(char))
 
-        total = (sum(evens) * 3) + sum(odds)
-        return (10 - (total % 10) + total) - total
+        return (10 - (((3 * sum(evens)) + sum(odds)) % 10)) % 10
 
     def check_fields(self):
         """

--- a/epc/schemes/tests/test_sgln.py
+++ b/epc/schemes/tests/test_sgln.py
@@ -150,3 +150,8 @@ class SGLNTest(TestCase):
 
         epc = SGLN(barcode='4140000010000014254!"%&\'()*+,-./012', company_prefix_length=6)
         self.assertEqual(hex(epc), '0x39180000400002851254c9d42954ad62d5cbd831640000000000')
+
+    def test_check_digit(self):
+        """Test SGLN Check Digit Calcuation"""
+        epc = SGLN().company_prefix('2488320').location_reference(22830).extension(0)
+        self.assertEqual(epc.calc_check_digit(), 0)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='epc,rfid,gid,giai,gid,grai,sgln,encoding,decoding,barcodes',
 )


### PR DESCRIPTION
Function `call_check_digit` in module `SGLN.py` returns 10 in edge cases where the computed value of `total` is a multiple of 10.

Simple code to check:

```
from epc.schemes import SGLN

tag = SGLN()
tag.company_prefix('2488320')
tag.location_reference(22830)
tag.extension(0)

print(tag.calc_check_digit())  # returns 10 instead of 0
print(tag.barcode)  # barcode output is also invalid
```

I shamelessly copied over the return function from `GRAI.py` where the same function is implemented just right.